### PR TITLE
Fix blank line cause compile error

### DIFF
--- a/talk-web/gulpfile.coffee
+++ b/talk-web/gulpfile.coffee
@@ -1,4 +1,3 @@
-
 fs = require 'fs'
 path = require 'path'
 gulp = require 'gulp'


### PR DESCRIPTION
```
> talk-account@0.3.6-rc1 static /Users/afc163/Projects/talk-os/talk-account
> NODE_ENV=static gulp build

[16:20:12] Failed to load external module coffee-script/register
[16:20:12] Failed to load external module coffee-script
/Users/afc163/Projects/talk-os/talk-account/gulpfile.coffee:1
(function (exports, require, module, __filename, __dirname) { fs = require 'fs'
                                                                           ^^^^

SyntaxError: Unexpected string
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:404:25)
    at Object.Module._extensions..js (module.js:432:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:313:12)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Liftoff.handleArguments (/Users/afc163/Projects/talk-os/talk-account/node_modules/gulp/bin/gulp.js:116:3)
    at Liftoff.<anonymous> (/Users/afc163/Projects/talk-os/talk-account/node_modules/liftoff/index.js:193:16)
    at module.exports (/Users/afc163/Projects/talk-os/talk-account/node_modules/flagged-respawn/index.js:17:3)
```