### PR TITLE
fix: talk-web 本地开发添加环境变量

### DIFF
--- a/talk-web/README.md
+++ b/talk-web/README.md
@@ -32,7 +32,7 @@ Name | github
 
 ```bash
 npm i
-gulp dev
+NODE_ENV=dev gulp dev
 ```
 
 ### Gulp builds

--- a/talk-web/package.json
+++ b/talk-web/package.json
@@ -51,7 +51,7 @@
     "webpack-dev-server": "1.9.0"
   },
   "scripts": {
-    "watch": "gulp dev",
+    "watch": "NODE_ENV=dev gulp dev",
     "test": "karma start --single-run",
     "test-dev": "karma start",
     "static": "NODE_ENV=static gulp build",


### PR DESCRIPTION
没有默认环境变量会导致在 talk-web 下起`npm run watch`或`gulp dev`后资源请求不到，所以在这里加上。 #35 